### PR TITLE
fix: json parse

### DIFF
--- a/BrowserStorageManager.js
+++ b/BrowserStorageManager.js
@@ -11,6 +11,10 @@ async function getItemFromLocal(item, default_value) {
     updating_storage = true;
     const value_from_storage = await browser.storage.local.get({ [item]: default_value });
     updating_storage = false;
+
+    if (value_from_storage) {
+        return JSON.parse(value_from_storage);
+    }
     return value_from_storage;
 }
 


### PR DESCRIPTION
Fixes https://github.com/ACK-J/Port_Authority/issues/27

Issue is local storage items were being set with JSON.stringify but when retrieving items there was no JSON.parse. This lead to addition escape characters "/" being appended to string in local storage. This repeated until RAM ran out.
