### PR TITLE
fix: allow domain whitelisting by url.host

### DIFF
--- a/background.js
+++ b/background.js
@@ -88,10 +88,9 @@ async function cancel(requestDetails) {
     const allowed_domains_list = await getItemFromLocal("allowed_domain_list", []);
     
     const check_allowed_url = new URL(requestDetails.originUrl)
-    // Check if the requesting domain is in the whitelist
-    if (allowed_domains_list.some((domain) => {
-        return check_allowed_url.host.includes(domain);
-    })){
+
+    const domainIsWhiteListed = allowed_domains_list.some((domain) => check_allowed_url.host.includes(domain));
+    if (domainIsWhiteListed){
         return { cancel: false };
     }
 

--- a/background.js
+++ b/background.js
@@ -84,17 +84,20 @@ async function cancel(requestDetails) {
     // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
     let thm = new RegExp("online-metrix[.]net$", "i");
 
-    // This reduces having to check this conditional multiple times
-    let is_requested_local = requestDetails.url.search(local_filter);
-
+    
     const allowed_domains_list = await getItemFromLocal("allowed_domain_list", []);
-
-    let check_allowed_url = new URL(requestDetails.originUrl)
+    
+    const check_allowed_url = new URL(requestDetails.originUrl)
     // Check if the requesting domain is in the whitelist
-    if (allowed_domains_list.includes(check_allowed_url.host.replace(/^(www\.)/,""))){
+    if (allowed_domains_list.some((domain) => {
+        return check_allowed_url.host.includes(domain);
+    })){
         return { cancel: false };
     }
 
+    // This reduces having to check this conditional multiple times
+    let is_requested_local = requestDetails.url.search(local_filter);
+    
     // Make sure we are not searching the CNAME of local addresses
     if (is_requested_local !== 0) {
         // Parse the URL

--- a/manifest.json
+++ b/manifest.json
@@ -45,6 +45,19 @@
     }
   },
 
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "popup/PopupUI.js",
+        "popup/settings.js",
+        "popup/switch.js"
+      ]
+    }
+  ],
+
   "options_ui": {
     "page": "popup/settings.html"
   }

--- a/popup/PopupUI.js
+++ b/popup/PopupUI.js
@@ -128,60 +128,51 @@ async function updateBlockedPortsDisplay() {
     // Add the header to the blocked hosts wrapper element
     all_ports_wrapper.appendChild(all_ports_header);
 
-    try {
-        // Grab the blocked ports from the extensions local storage.
-        const blocked_ports_tabs = await getItemFromLocal(
-            "blocked_ports",
-            {}
+    // Grab the blocked ports from the extensions local storage.
+    const blocked_ports_tabs = await getItemFromLocal("blocked_ports", {});
+
+    if (Object.entries(blocked_ports_tabs).length === 0) {
+        // Nothing to render
+        return;
+    }
+
+    const blocked_ports = blocked_ports_tabs[tabId] || {};
+
+    const hosts = Object.keys(blocked_ports);
+
+    // build a tree for each host that was blocked
+    for (let i_host = 0; i_host < hosts.length; i_host++) {
+        // Build the wrapper for displaying the host name and ports blocked
+        const host = hosts[i_host];
+        const host_id = `host${i_host}`;
+        const host_wrapper = buildCollapseWrapperAndToggle(
+            host_id,
+            host,
+            "View Ports"
         );
 
-        if (
-            Object.entries(blocked_ports_tabs).length !== 0
-        ) {
-            const blocked_ports = blocked_ports_tabs[tabId] || {};
+        // build the list of blocked ports then append it to the wrapper
+        const hosts_ul = document.createElement("div");
+        hosts_ul.id = host_id;
+        hosts_ul.classList.add("list-unstyled", "collapse");
 
-            const hosts = Object.keys(blocked_ports);
+        const ports = blocked_ports[hosts[i_host]];
 
-            // build a tree for each host that was blocked
-            for (let i_host = 0; i_host < hosts.length; i_host++) {
-                // Build the wrapper for displaying the host name and ports blocked
-                const host = hosts[i_host];
-                const host_id = `host${i_host}`;
-                const host_wrapper = buildCollapseWrapperAndToggle(
-                    host_id,
-                    host,
-                    "View Ports"
-                );
+        // Add each port to the HTML
+        for (let i_port = 0; i_port < ports.length; i_port++) {
+            const port = ports[i_port];
+            const port_element = document.createElement("div");
+            port_element.innerText = port;
+            port_element.classList.add("ps-2");
+            hosts_ul.appendChild(port_element);
+        }
 
-                // build the list of blocked ports then append it to the wrapper
-                const hosts_ul = document.createElement("div");
-                hosts_ul.id = host_id;
-                hosts_ul.classList.add("list-unstyled", "collapse");
-
-                const ports = blocked_ports[hosts[i_host]];
-
-                // Add each port to the HTML
-                for (let i_port = 0; i_port < ports.length; i_port++) {
-                    const port = ports[i_port];
-                    const port_element = document.createElement("div");
-                    port_element.innerText = port;
-                    port_element.classList.add("ps-2");
-                    hosts_ul.appendChild(port_element);
-                }
-
-                host_wrapper.appendChild(hosts_ul);
-                all_ports_wrapper.appendChild(host_wrapper);
-            }
-
-            blocked_data_display.appendChild(all_ports_wrapper);
-        } // else leave blank (prevents a JSON parsing error)
-    } catch (error) {
-        // If an error occurs clear any created elements
-        console.log(error);
-        all_ports_wrapper.innerText = "";
-        // Add the header to the blocked hosts wrapper element
-        all_ports_wrapper.appendChild(all_ports_header);
+        host_wrapper.appendChild(hosts_ul);
+        all_ports_wrapper.appendChild(host_wrapper);
     }
+
+    blocked_data_display.appendChild(all_ports_wrapper);
+
     // Append the header to the GUI
     const blocked_data_display_ports = document.getElementById(
         "blocked_data_display"

--- a/popup/settings.html
+++ b/popup/settings.html
@@ -16,8 +16,8 @@
     </form>
     <br />
     <p><strong>Domains Allowed to Bypass PortAuthority Blocking:</strong></p>
-    <div class="row" id="allowedDomainsListID">
-    </div>
+    <ul id="allowedDomainsListID">
+    </ul>
     <br />
     <script type="module" src="settings.js"></script>
 </body>

--- a/popup/settings.js
+++ b/popup/settings.js
@@ -1,7 +1,7 @@
 let updating_storage = false;
 
 function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function getItemFromLocal(item, default_value) {
@@ -9,11 +9,13 @@ async function getItemFromLocal(item, default_value) {
         await sleep(500);
     }
     updating_storage = true;
-    const value_from_storage = await browser.storage.local.get({ [item]: default_value });
+    const value_from_storage = await browser.storage.local.get({
+        [item]: default_value,
+    });
     updating_storage = false;
-    try{
+    try {
         return JSON.parse(value_from_storage[item]);
-    }catch {
+    } catch {
         return default_value;
     }
 }
@@ -28,40 +30,79 @@ async function setItemInLocal(key, value) {
     return;
 }
 
-async function load_allowed_domains(){
-    const allowedDomainsList = await getItemFromLocal("allowed_domain_list", []);
-    const domainDomElements = allowedDomainsList.map(domain => {
-        return `<li>${domain}</li>`;
-    })
-
-    const allowDomainsListDomElement = document.getElementById("allowedDomainsListID");
-    allowDomainsListDomElement.innerHTML = domainDomElements.join("");
+async function handleClick(e) {
+    if (e.target.dataset.action === "removeDomain" && e.target.dataset.domain) {
+        const allowedDomainsList = await getItemFromLocal(
+            "allowed_domain_list",
+            []
+        );
+        const newAllowedDomainsList = allowedDomainsList.filter(
+            (domain) => domain !== e.target.dataset.domain
+        );
+        await setItemInLocal("allowed_domain_list", newAllowedDomainsList);
+        load_allowed_domains();
+    }
 }
 
-async function saveOptions(e) {  
-    const allowed_domains_list = await getItemFromLocal("allowed_domain_list", []);
+async function load_allowed_domains() {
+    // Remove the current event listener to avoid multiple event listeners
+    if (
+        document.querySelector("button").addEventListener("click", handleClick)
+    ) {
+        document
+            .querySelector("button")
+            .removeEventListener("click", handleClick);
+    }
+
+    document.querySelector("button").addEventListener("click", handleClick);
+    const allowedDomainsList = await getItemFromLocal(
+        "allowed_domain_list",
+        []
+    );
+
+    const domainDomElements = allowedDomainsList.map((domain) => {
+        const button = document.createElement("button");
+        button.innerHTML = "Remove";
+        button.dataset.domain = domain;
+        button.dataset.action = "removeDomain";
+
+        return `<li>${domain} ${button.outerHTML}</li>`;
+    });
+
+    const allowDomainsListDomElement = document.getElementById(
+        "allowedDomainsListID"
+    );
+    allowDomainsListDomElement.innerHTML = domainDomElements.join("");
+    allowDomainsListDomElement.addEventListener("click", handleClick);
+}
+
+async function saveOptions(e) {
+    const allowed_domains_list = await getItemFromLocal(
+        "allowed_domain_list",
+        []
+    );
 
     // We don't actually care about the protocol as we only compare url.host
     // But the URL object will fail to create if no protocol is provided
     let url = e.target[0].value + "";
-    if(url.slice(0, 4) != "http"){
+    if (url.slice(0, 4) != "http") {
         url = "https://" + url;
     }
-    try{
+    try {
         const newUrl = new URL(url);
         const newUrlHost = newUrl.host;
-        if(allowed_domains_list.indexOf(newUrlHost) !== -1){
+        if (allowed_domains_list.indexOf(newUrlHost) !== -1) {
             alert("This domain is already in the list.");
             return;
         }
         allowed_domains_list.push(newUrlHost);
-        await setItemInLocal('allowed_domain_list', allowed_domains_list);
+        await setItemInLocal("allowed_domain_list", allowed_domains_list);
     } catch (error) {
         console.error(error);
         alert("Please enter a valid domain.");
         return;
     }
-  }
-  
+}
+
 load_allowed_domains();
 document.querySelector("form").addEventListener("submit", saveOptions);


### PR DESCRIPTION
Spoke with @ACK-J on how whitelisting is intended to filter and we decided on domain-based (so no path specific).

Whitelisting works by checking if a requests URL's `host` property contains the `host` property of whitelisted domain.

Given we are whitelisting by host if you wish to whitelist an entire domain you must ensure to **NOT** register a subdomain in the whitelist.

For example: 
If you whitelist `foo.bar.com` and then navigate to `bar.com` then requests **WILL** be blocked. But if you go to `foo.bar.com` requests **WILL NOT** be blocked

On the flip side, if you whitelist `bar.com` and then go to `foo.bar.com` requests **WILL NOT** be blocked.