### PR TITLE
fix: slow image load times

### DIFF
--- a/BrowserStorageManager.js
+++ b/BrowserStorageManager.js
@@ -8,9 +8,7 @@ async function getItemFromLocal(item, default_value) {
     while (updating_storage) {
         await sleep(500);
     }
-    updating_storage = true;
     const value_from_storage = await browser.storage.local.get({ [item]: default_value });
-    updating_storage = false;
 
     try{
         return JSON.parse(value_from_storage[item]);


### PR DESCRIPTION
Resolves issue #32 

Fixed an issue causing slow image load times. 

The error was occurring due to locking the "updating_storage" flag when accessing local storage, followed by a 0.5 second wait. 