### PR TITLE
Stricter same-origin/first-party checks and preventing `localhost.example.com` from being able to run portscans. Fixes #54

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,7 +35,7 @@ async function cancel(requestDetails) {
                 console.warn("`requestDetails.thirdParty` and our check of origins disagree:", {origin, request, thirdParty: requestDetails.thirdParty});
             }
         } catch(error) {
-            console.error("Error parsing request `originUrl` or `url`:", requestDetails);
+            console.error("Error parsing request `originUrl` or `url`:", requestDetails, error);
         }
     }
 
@@ -44,8 +44,8 @@ async function cancel(requestDetails) {
     let check_allowed_url;
     try {
         check_allowed_url = new URL(requestDetails.originUrl);
-    } catch {
-        console.error("Aborted filtering on domain due to unparseable originUrl: ", requestDetails.originUrl);
+    } catch(error) {
+        console.error("Aborted filtering on domain due to unparseable originUrl: ", requestDetails.originUrl, error);
         return { cancel: false }; // invalid origin
     }
     const allowed_domains_list = await getItemFromLocal("allowed_domain_list", []);
@@ -59,8 +59,12 @@ async function cancel(requestDetails) {
     }
 
     // Used in both local and threatmetrix checks
-    // TODO wrap in try-catch
-    const url = new URL(requestDetails.url);
+    let url;
+    try {
+        url = new URL(requestDetails.url);
+    } catch(error) {
+        console.error("Error filtering on domain due to unparseable request URL: ", requestDetails.url, error);
+    }
 
 
     // Local request check


### PR DESCRIPTION
This fixes most of #54  by no longer allowing all requests whose origin is counted as local by the regex (which false-positives on `localhost.any.domain`) make any local requests (except to their own origin).

To verify this change is needed you can go to https://localhost.mws.is and run a portscan, before this PR all LAN access attempts are un-blocked and with this PR they should fail.

Unfortunately this also means that LAN apps will now need to be manually added to the allowlist if they call LAN addresses other than their own. Plan to add an option in the future to "allowlist" all LAN services to restore that functionality, but for now it's broken. There are potentially some issues with adding LAN apps to the allowlist (see #51) but at the moment I can't reproduce the issue to see if this would have any impact.