### PR TITLE
Improve the test page

### DIFF
--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 </head>
@@ -153,22 +154,21 @@ padding-bottom: 20px; width: 500px; margin: auto; text-align: center;padding-top
 
     function custom_scan()
     {
-        var ips = {"127.0.0.1": 80, "127.0.0.1": 8081, "localhost": 8080, "LoCALhOst": 443, "10.0.0.1": 455, "10.255.22.33": 80, "192.168.1.1": 443, "192.168.1.255":6463, "172.17.100.155": 4444,  "172.31.255.255": 8081, "172.031.33.33": 445, "169.254.1.0": 547, "169.254.1.0": 21, "169.254.1.0": 194};
-        var scripts = {"fp.disney.go.com": 443, "h.chase.co.uk": 443, "analytics.vacations.united.com": 443, "tmx.bestbuy.com": 443, "thm12.visa.com": 443, "tmetrix.my.chick-fil-a.com": 443, "cfa.fidelity.com": 443, "content22.citibank.com": 443, "deviceauth.dmv.ca.gov": 443, "dfp.t-mobile.at": 443, "src.ebay-us.com": 443, "fp.disney.go.com": 443, "fp.ups.com": 443};
+        const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
+        const scripts = [{"fp.disney.go.com": 443}, {"h.chase.co.uk": 443}, {"analytics.vacations.united.com": 443}, {"tmx.bestbuy.com": 443}, {"thm12.visa.com": 443}, {"tmetrix.my.chick-fil-a.com": 443}, {"cfa.fidelity.com": 443}, {"content22.citibank.com": 443}, {"deviceauth.dmv.ca.gov": 443}, {"dfp.t-mobile.at": 443}, {"src.ebay-us.com": 443}, {"fp.disney.go.com": 443}, {"fp.ups.com": 443}];
 
         document.getElementById("custom_button").disabled = true;
         document.getElementById("requestsmade").style.visibility="visible";
 
-        var res_div = document.getElementById("results");
-        res_div.innerHTML = "";
+        const res_div = document.getElementById("results");
+        res_div.innerText = "";
 
-        for(var ip in ips){
-            var port = ips[ip];
-            port = parseInt(port);
+        for(const item of ips){
+            const [ip, port] = Object.entries(item)[0];
             if (isNaN(port) || port <= 0 || port > 65535) {
                 alert("Bad port number");
             }
-            var scanner = new PortScanner(ip, port);
+            const scanner = new PortScanner(ip, port);
 
             scanner.runHTTP();
             scanner.runHTTPS();
@@ -176,13 +176,12 @@ padding-bottom: 20px; width: 500px; margin: auto; text-align: center;padding-top
             scanner.wss();
         }
 
-        for(var host in scripts){
-            var port = scripts[host];
-            port = parseInt(port);
+        for(const item of scripts){
+            const [host, port] = Object.entries(item)[0];
             if (isNaN(port) || port < 0 || port > 65535) {
                 alert("Bad port number");
             }
-            var scanner = new PortScanner(host, port);
+            const scanner = new PortScanner(host, port);
 
             scanner.runHTTPS();
         }

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -1,193 +1,195 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All in One Port-Scan Test</title>
 </head>
+<body>
+    <div style="border: solid black 5px; border-radius: 10px; background-color: #da5a5a; padding-left: 20px; padding-right: 20px;
+    padding-bottom: 20px; width: 500px; margin: auto; text-align: center;padding-top: 10px;">
 
-<div style="border: solid black 5px; border-radius: 10px; background-color: #da5a5a; padding-left: 20px; padding-right: 20px;
-padding-bottom: 20px; width: 500px; margin: auto; text-align: center;padding-top: 10px;">
-
-    <p>
-        <strong style="color: white; font-size: 30px;">All in One Port-Scan Test</strong>
-    </p>
-
-    <input type="button" style="font-size: 18px; padding: 6px; background-color: #e7e7e7;" id="custom_button" value="Port Scan My Internal Network!" onclick="custom_scan();" />
-     
-    <div style="color: white;">
-        <br>
         <p>
-            <strong>
-                By clicking the button above, you understand that this is a portscanning test that happens inside your browser and is specifically built to test all the possible ways a site can port scan you in one easy location. 
-                It will also try to reach out to specific domains that are known for distributing privacy-invasive scripts but will not attempt to download these scripts. NO DATA WILL EVER BE LOGGED OR SENT TO ME!
-                <br>   
-                <div>
-                    <a href="https://addons.mozilla.org/en-US/firefox/addon/port-authority/">
-                        <img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt="for Firefox" height="60px" />
-                    </a>
-                </div> 
-                <br>
-                If you download the Port Authority add-on, your browser will block all malicious port scans and scripts.
-            </strong>        
+            <strong style="color: white; font-size: 30px;">All in One Port-Scan Test</strong>
         </p>
-    </div>
-        <p style="color: white;font-weight: bold;visibility: hidden;font-size: 26px;" id="requestsmade">
-            <strong>
-                Requests Made
-            </strong>
-        </p>
-    <div>
-        <div id="results" style="padding-top: 10px; color: white;font-weight: bold;"></div>
-    </div>
 
-</div>
-
-
-<div id="testdiv" style="visibility: hidden"></div>
-
-<script>
-
-    /* The scanner needs these global variables for an ugly hack. */
-    var last_scanobj_index = 0;
-    var scanobjs = {};
-    function PortScanner(ip, port)
-    {
+        <input type="button" style="font-size: 18px; padding: 6px; background-color: #e7e7e7;" id="custom_button" value="Port Scan My Internal Network!" onclick="custom_scan();" />
         
-        this.ip = ip;
-        this.port = port;
-        this.total_time = null;
+        <div style="color: white;">
+            <br>
+            <p>
+                <strong>
+                    By clicking the button above, you understand that this is a portscanning test that happens inside your browser and is specifically built to test all the possible ways a site can port scan you in one easy location. 
+                    It will also try to reach out to specific domains that are known for distributing privacy-invasive scripts but will not attempt to download these scripts. NO DATA WILL EVER BE LOGGED OR SENT TO ME!
+                    <br>   
+                    <div>
+                        <a href="https://addons.mozilla.org/en-US/firefox/addon/port-authority/">
+                            <img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt="for Firefox" height="60px" />
+                        </a>
+                    </div> 
+                    <br>
+                    If you download the Port Authority add-on, your browser will block all malicious port scans and scripts.
+                </strong>        
+            </p>
+        </div>
+            <p style="color: white;font-weight: bold;visibility: hidden;font-size: 26px;" id="requestsmade">
+                <strong>
+                    Requests Made
+                </strong>
+            </p>
+        <div>
+            <div id="results" style="padding-top: 10px; color: white;font-weight: bold;"></div>
+        </div>
 
-        this.runHTTP = function () {
-
-            /* Save this object in the global directory (UGLY HACK). */
-            var our_scanobj_index = last_scanobj_index;
-            last_scanobj_index++;
-            scanobjs[our_scanobj_index] = this;
-
-            /* Create the div to load the image, passing our object's index into
-                the global directory so that it can be retrieved. */
-            document.getElementById("testdiv").innerHTML = '<img src="http://' + ip + ':' + port + 
-                '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
-
-            var res_div = document.getElementById("results");
-            res_div.innerHTML += "http://" + ip + ":" + port + "<br />";
-
-            // XXX: What's the right way to do this in JS?
-            var thiss = this;
-            setTimeout(
-                function () {
-                    /* This will be non-null if the event hasn't fired yet. */
-                    if (scanobjs[our_scanobj_index]) {
-                        scanobjs[our_scanobj_index] = null;
-                    }
-                },
-                10000
-            );
-        }
-
-        this.runHTTPS = function () {
-
-            /* Save this object in the global directory (UGLY HACK). */
-            var our_scanobj_index = last_scanobj_index;
-            last_scanobj_index++;
-            scanobjs[our_scanobj_index] = this;
-
-            /* Create the div to load the image, passing our object's index into
-                the global directory so that it can be retrieved. */
-            document.getElementById("testdiv").innerHTML = '<img src="https://' + ip + ':' + port + 
-                '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
+    </div>
 
 
-            var res_div = document.getElementById("results");
-            res_div.innerHTML += "https://" + ip + ":" + port + "<br />";
+    <div id="testdiv" style="visibility: hidden"></div>
 
-            // XXX: What's the right way to do this in JS?
-            var thiss = this;
-            setTimeout(
-                function () {
-                    /* This will be non-null if the event hasn't fired yet. */
-                    if (scanobjs[our_scanobj_index]) {
-                        scanobjs[our_scanobj_index] = null;
-                    }
-                },
-                10000
-            );
-        }
+    <script>
 
-        this.ws = function() {
-        return new Promise((resolve, reject) => {
-            var ws = new WebSocket("ws://" + ip +":" + port + '/')
-            var res_div = document.getElementById("results");
-            res_div.innerHTML += "ws://" + ip + ":" + port + "<br />";
-            ws.onerror = function() {
-            // close the socket before we return
-            ws.close()
+        /* The scanner needs these global variables for an ugly hack. */
+        var last_scanobj_index = 0;
+        var scanobjs = {};
+        function PortScanner(ip, port)
+        {
+            
+            this.ip = ip;
+            this.port = port;
+            this.total_time = null;
+
+            this.runHTTP = function () {
+
+                /* Save this object in the global directory (UGLY HACK). */
+                var our_scanobj_index = last_scanobj_index;
+                last_scanobj_index++;
+                scanobjs[our_scanobj_index] = this;
+
+                /* Create the div to load the image, passing our object's index into
+                    the global directory so that it can be retrieved. */
+                document.getElementById("testdiv").innerHTML = '<img src="http://' + ip + ':' + port + 
+                    '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
+
+                var res_div = document.getElementById("results");
+                res_div.innerHTML += "http://" + ip + ":" + port + "<br />";
+
+                // XXX: What's the right way to do this in JS?
+                var thiss = this;
+                setTimeout(
+                    function () {
+                        /* This will be non-null if the event hasn't fired yet. */
+                        if (scanobjs[our_scanobj_index]) {
+                            scanobjs[our_scanobj_index] = null;
+                        }
+                    },
+                    10000
+                );
             }
-        })
-        }
 
-        this.wss = function() {
-        return new Promise((resolve, reject) => {
-            var ws = new WebSocket("wss://" + ip +":" + port + '/')
-            var res_div = document.getElementById("results");
-            res_div.innerHTML += "wss://" + ip + ":" + port + "<br />";
-            ws.onerror = function() {
-            // close the socket before we return
-            ws.close()
+            this.runHTTPS = function () {
+
+                /* Save this object in the global directory (UGLY HACK). */
+                var our_scanobj_index = last_scanobj_index;
+                last_scanobj_index++;
+                scanobjs[our_scanobj_index] = this;
+
+                /* Create the div to load the image, passing our object's index into
+                    the global directory so that it can be retrieved. */
+                document.getElementById("testdiv").innerHTML = '<img src="https://' + ip + ':' + port + 
+                    '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
+
+
+                var res_div = document.getElementById("results");
+                res_div.innerHTML += "https://" + ip + ":" + port + "<br />";
+
+                // XXX: What's the right way to do this in JS?
+                var thiss = this;
+                setTimeout(
+                    function () {
+                        /* This will be non-null if the event hasn't fired yet. */
+                        if (scanobjs[our_scanobj_index]) {
+                            scanobjs[our_scanobj_index] = null;
+                        }
+                    },
+                    10000
+                );
             }
-        })
-        }
-    }
 
-
-
-    function error_handler(index)
-    {
-        /* Get the PortScanner object back. */
-        var thiss = scanobjs[index];
-
-        /* If it's null, the scan timed out. */
-        if (thiss == null) {
-            return;
-        }
-        /* Set it to null so the timeout knows we handled it. */
-        scanobjs[index] = null;
-    }
-
-    function custom_scan()
-    {
-        const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
-        const scripts = [{"fp.disney.go.com": 443}, {"h.chase.co.uk": 443}, {"analytics.vacations.united.com": 443}, {"tmx.bestbuy.com": 443}, {"thm12.visa.com": 443}, {"tmetrix.my.chick-fil-a.com": 443}, {"cfa.fidelity.com": 443}, {"content22.citibank.com": 443}, {"deviceauth.dmv.ca.gov": 443}, {"dfp.t-mobile.at": 443}, {"src.ebay-us.com": 443}, {"fp.disney.go.com": 443}, {"fp.ups.com": 443}];
-
-        document.getElementById("custom_button").disabled = true;
-        document.getElementById("requestsmade").style.visibility="visible";
-
-        const res_div = document.getElementById("results");
-        res_div.innerText = "";
-
-        for(const item of ips){
-            const [ip, port] = Object.entries(item)[0];
-            if (isNaN(port) || port <= 0 || port > 65535) {
-                alert("Bad port number");
+            this.ws = function() {
+            return new Promise((resolve, reject) => {
+                var ws = new WebSocket("ws://" + ip +":" + port + '/')
+                var res_div = document.getElementById("results");
+                res_div.innerHTML += "ws://" + ip + ":" + port + "<br />";
+                ws.onerror = function() {
+                // close the socket before we return
+                ws.close()
+                }
+            })
             }
-            const scanner = new PortScanner(ip, port);
 
-            scanner.runHTTP();
-            scanner.runHTTPS();
-            scanner.ws();
-            scanner.wss();
-        }
-
-        for(const item of scripts){
-            const [host, port] = Object.entries(item)[0];
-            if (isNaN(port) || port < 0 || port > 65535) {
-                alert("Bad port number");
+            this.wss = function() {
+            return new Promise((resolve, reject) => {
+                var ws = new WebSocket("wss://" + ip +":" + port + '/')
+                var res_div = document.getElementById("results");
+                res_div.innerHTML += "wss://" + ip + ":" + port + "<br />";
+                ws.onerror = function() {
+                // close the socket before we return
+                ws.close()
+                }
+            })
             }
-            const scanner = new PortScanner(host, port);
-
-            scanner.runHTTPS();
         }
-        document.getElementById("custom_button").disabled = false;
 
-    }
 
-</script>
+
+        function error_handler(index)
+        {
+            /* Get the PortScanner object back. */
+            var thiss = scanobjs[index];
+
+            /* If it's null, the scan timed out. */
+            if (thiss == null) {
+                return;
+            }
+            /* Set it to null so the timeout knows we handled it. */
+            scanobjs[index] = null;
+        }
+
+        function custom_scan()
+        {
+            const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
+            const scripts = [{"fp.disney.go.com": 443}, {"h.chase.co.uk": 443}, {"analytics.vacations.united.com": 443}, {"tmx.bestbuy.com": 443}, {"thm12.visa.com": 443}, {"tmetrix.my.chick-fil-a.com": 443}, {"cfa.fidelity.com": 443}, {"content22.citibank.com": 443}, {"deviceauth.dmv.ca.gov": 443}, {"dfp.t-mobile.at": 443}, {"src.ebay-us.com": 443}, {"fp.disney.go.com": 443}, {"fp.ups.com": 443}];
+
+            document.getElementById("custom_button").disabled = true;
+            document.getElementById("requestsmade").style.visibility="visible";
+
+            const res_div = document.getElementById("results");
+            res_div.innerText = "";
+
+            for(const item of ips){
+                const [ip, port] = Object.entries(item)[0];
+                if (isNaN(port) || port <= 0 || port > 65535) {
+                    alert("Bad port number");
+                }
+                const scanner = new PortScanner(ip, port);
+
+                scanner.runHTTP();
+                scanner.runHTTPS();
+                scanner.ws();
+                scanner.wss();
+            }
+
+            for(const item of scripts){
+                const [host, port] = Object.entries(item)[0];
+                if (isNaN(port) || port < 0 || port > 65535) {
+                    alert("Bad port number");
+                }
+                const scanner = new PortScanner(host, port);
+
+                scanner.runHTTPS();
+            }
+            document.getElementById("custom_button").disabled = false;
+        }
+    </script>
+</body>
 </html>

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -44,7 +44,7 @@
         <p>
             If you download the Port Authority add-on, your browser will block all malicious port scans and scripts.
         </p>
-        <h2 id="requestsmade" style="visibility: hidden;">
+        <h2 id="requestsmade" hidden>
             Requests Made
         </h2>
         <div id="results" style="padding-top: 10px; font-weight: bold;"></div>
@@ -53,13 +53,20 @@
     <div id="testdiv" hidden></div>
 
     <script>
+        /* DOM nodes */
+        const trigger_portscan_button = document.getElementById("custom_button");
+        const res_div = document.getElementById("results");
+        const test_div = document.getElementById("testdiv");
 
         /* The scanner needs these global variables for an ugly hack. */
         var last_scanobj_index = 0;
         var scanobjs = {};
         function PortScanner(ip, port)
         {
-            
+            // Verify port format
+            if (isNaN(port) || port <= 0 || port > 65535) {
+                alert("Bad port number");
+            }
             this.ip = ip;
             this.port = port;
             this.total_time = null;
@@ -73,10 +80,8 @@
 
                 /* Create the div to load the image, passing our object's index into
                     the global directory so that it can be retrieved. */
-                document.getElementById("testdiv").innerHTML = '<img src="http://' + ip + ':' + port + 
+                test_div.innerHTML = '<img src="http://' + ip + ':' + port + 
                     '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
-
-                var res_div = document.getElementById("results");
                 res_div.innerHTML += "http://" + ip + ":" + port + "<br />";
 
                 // XXX: What's the right way to do this in JS?
@@ -101,11 +106,9 @@
 
                 /* Create the div to load the image, passing our object's index into
                     the global directory so that it can be retrieved. */
-                document.getElementById("testdiv").innerHTML = '<img src="https://' + ip + ':' + port + 
+                test_div.innerHTML = '<img src="https://' + ip + ':' + port + 
                     '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
 
-
-                var res_div = document.getElementById("results");
                 res_div.innerHTML += "https://" + ip + ":" + port + "<br />";
 
                 // XXX: What's the right way to do this in JS?
@@ -124,7 +127,6 @@
             this.ws = function() {
             return new Promise((resolve, reject) => {
                 var ws = new WebSocket("ws://" + ip +":" + port + '/')
-                var res_div = document.getElementById("results");
                 res_div.innerHTML += "ws://" + ip + ":" + port + "<br />";
                 ws.onerror = function() {
                 // close the socket before we return
@@ -136,7 +138,6 @@
             this.wss = function() {
             return new Promise((resolve, reject) => {
                 var ws = new WebSocket("wss://" + ip +":" + port + '/')
-                var res_div = document.getElementById("results");
                 res_div.innerHTML += "wss://" + ip + ":" + port + "<br />";
                 ws.onerror = function() {
                 // close the socket before we return
@@ -166,17 +167,13 @@
             const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
             const scripts = [{"fp.disney.go.com": 443}, {"h.chase.co.uk": 443}, {"analytics.vacations.united.com": 443}, {"tmx.bestbuy.com": 443}, {"thm12.visa.com": 443}, {"tmetrix.my.chick-fil-a.com": 443}, {"cfa.fidelity.com": 443}, {"content22.citibank.com": 443}, {"deviceauth.dmv.ca.gov": 443}, {"dfp.t-mobile.at": 443}, {"src.ebay-us.com": 443}, {"fp.disney.go.com": 443}, {"fp.ups.com": 443}];
 
-            document.getElementById("custom_button").disabled = true;
-            document.getElementById("requestsmade").style.visibility="visible";
+            trigger_portscan_button.disabled = true;
+            document.getElementById("requestsmade").hidden = false;
 
-            const res_div = document.getElementById("results");
             res_div.innerText = "";
 
             for(const item of ips){
                 const [ip, port] = Object.entries(item)[0];
-                if (isNaN(port) || port <= 0 || port > 65535) {
-                    alert("Bad port number");
-                }
                 const scanner = new PortScanner(ip, port);
 
                 scanner.runHTTP();
@@ -187,14 +184,11 @@
 
             for(const item of scripts){
                 const [host, port] = Object.entries(item)[0];
-                if (isNaN(port) || port < 0 || port > 65535) {
-                    alert("Bad port number");
-                }
                 const scanner = new PortScanner(host, port);
 
                 scanner.runHTTPS();
             }
-            document.getElementById("custom_button").disabled = false;
+            trigger_portscan_button.disabled = false;
         }
     </script>
 </body>

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -164,7 +164,7 @@
 
         function custom_scan()
         {
-            const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
+            const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost.": 80}, {"localhost.": 8080}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
             const scripts = ["fp.disney.go.com", "h.chase.co.uk", "analytics.vacations.united.com", "tmx.bestbuy.com", "thm12.visa.com", "tmetrix.my.chick-fil-a.com", "cfa.fidelity.com", "content22.citibank.com", "deviceauth.dmv.ca.gov", "dfp.t-mobile.at", "src.ebay-us.com", "fp.disney.go.com", "fp.ups.com"];
 
             trigger_portscan_button.disabled = true;

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -68,6 +68,7 @@
                 alert("Bad port number");
             }
             const host = ip + ":" + port;
+            this.host = host;
             this.total_time = null;
 
             this.runHTTP = function () {
@@ -164,7 +165,7 @@
         function custom_scan()
         {
             const ips = [{"127.0.0.1": 80}, {"127.0.0.1": 65535}, {"0.0.0.0": 80}, {"localhost": 8080}, {"localhost": 8081}, {"localhost": 8082}, {"localhost": 8083}, {"localhost": 8084}, {"localhost": 8085}, {"LoCALhOst": 443}, {"10.0.0.1": 455}, {"10.255.22.33": 80}, {"192.168.1.1": 443}, {"192.168.1.255":6463}, {"172.17.100.155": 4444}, {"172.31.255.255": 8081}, {"172.031.33.33": 445}, {"169.254.1.0": 547}, {"169.254.1.0": 21}, {"169.254.1.0": 194}];
-            const scripts = [{"fp.disney.go.com": 443}, {"h.chase.co.uk": 443}, {"analytics.vacations.united.com": 443}, {"tmx.bestbuy.com": 443}, {"thm12.visa.com": 443}, {"tmetrix.my.chick-fil-a.com": 443}, {"cfa.fidelity.com": 443}, {"content22.citibank.com": 443}, {"deviceauth.dmv.ca.gov": 443}, {"dfp.t-mobile.at": 443}, {"src.ebay-us.com": 443}, {"fp.disney.go.com": 443}, {"fp.ups.com": 443}];
+            const scripts = ["fp.disney.go.com", "h.chase.co.uk", "analytics.vacations.united.com", "tmx.bestbuy.com", "thm12.visa.com", "tmetrix.my.chick-fil-a.com", "cfa.fidelity.com", "content22.citibank.com", "deviceauth.dmv.ca.gov", "dfp.t-mobile.at", "src.ebay-us.com", "fp.disney.go.com", "fp.ups.com"];
 
             trigger_portscan_button.disabled = true;
             document.getElementById("requestsmade").hidden = false;
@@ -181,12 +182,11 @@
                 scanner.wss();
             }
 
-            for(const item of scripts){
-                const [host, port] = Object.entries(item)[0];
-                const scanner = new PortScanner(host, port);
-
+            for(const host of scripts){
+                const scanner = new PortScanner(host, 443);
                 scanner.runHTTPS();
             }
+            
             trigger_portscan_button.disabled = false;
         }
     </script>

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -6,24 +6,25 @@
     <title>All in One Port-Scan Test</title>
     <style>
         main {
-            border: solid black 5px;
-            border-radius: 10px;
-            background-color: #da5a5a;
-            padding-left: 20px;
-            padding-right: 20px;
-            padding-bottom: 20px;
             width: 500px;
             margin: auto;
-            text-align: center;
+            padding: 20px;
             padding-top: 10px;
+
+            border: solid black 5px;
+            border-radius: 10px;
+
+            background-color: #da5a5a;
+
             color: white;
             font-weight: bold;
+            text-align: center;
         }
 
         #custom_button {
-            font-size: 18px;
             padding: 6px;
             background-color: #e7e7e7;
+            font-size: 18px;
         }
     </style>
 </head>
@@ -49,7 +50,7 @@
         <div id="results" style="padding-top: 10px; font-weight: bold;"></div>
     </main>
 
-    <div id="testdiv" style="visibility: hidden"></div>
+    <div id="testdiv" hidden></div>
 
     <script>
 

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -16,6 +16,7 @@
             margin: auto;
             text-align: center;
             padding-top: 10px;
+            color: white;
         }
 
         #custom_button {
@@ -29,12 +30,12 @@
     <div id="main_content">
 
         <p>
-            <strong style="color: white; font-size: 30px;">All in One Port-Scan Test</strong>
+            <strong style="font-size: 30px;">All in One Port-Scan Test</strong>
         </p>
 
         <input type="button"id="custom_button" value="Port Scan My Internal Network!" onclick="custom_scan();" />
         
-        <div style="color: white;">
+        <div>
             <br>
             <p>
                 <strong>
@@ -51,13 +52,13 @@
                 </strong>        
             </p>
         </div>
-            <p style="color: white;font-weight: bold;visibility: hidden;font-size: 26px;" id="requestsmade">
+            <p style="font-weight: bold;visibility: hidden;font-size: 26px;" id="requestsmade">
                 <strong>
                     Requests Made
                 </strong>
             </p>
         <div>
-            <div id="results" style="padding-top: 10px; color: white;font-weight: bold;"></div>
+            <div id="results" style="padding-top: 10px; font-weight: bold;"></div>
         </div>
 
     </div>

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -4,16 +4,35 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>All in One Port-Scan Test</title>
+    <style>
+        #main_content {
+            border: solid black 5px;
+            border-radius: 10px;
+            background-color: #da5a5a;
+            padding-left: 20px;
+            padding-right: 20px;
+            padding-bottom: 20px;
+            width: 500px;
+            margin: auto;
+            text-align: center;
+            padding-top: 10px;
+        }
+
+        #custom_button {
+            font-size: 18px;
+            padding: 6px;
+            background-color: #e7e7e7;
+        }
+    </style>
 </head>
 <body>
-    <div style="border: solid black 5px; border-radius: 10px; background-color: #da5a5a; padding-left: 20px; padding-right: 20px;
-    padding-bottom: 20px; width: 500px; margin: auto; text-align: center;padding-top: 10px;">
+    <div id="main_content">
 
         <p>
             <strong style="color: white; font-size: 30px;">All in One Port-Scan Test</strong>
         </p>
 
-        <input type="button" style="font-size: 18px; padding: 6px; background-color: #e7e7e7;" id="custom_button" value="Port Scan My Internal Network!" onclick="custom_scan();" />
+        <input type="button"id="custom_button" value="Port Scan My Internal Network!" onclick="custom_scan();" />
         
         <div style="color: white;">
             <br>

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -67,8 +67,7 @@
             if (isNaN(port) || port <= 0 || port > 65535) {
                 alert("Bad port number");
             }
-            this.ip = ip;
-            this.port = port;
+            const host = ip + ":" + port;
             this.total_time = null;
 
             this.runHTTP = function () {
@@ -80,9 +79,9 @@
 
                 /* Create the div to load the image, passing our object's index into
                     the global directory so that it can be retrieved. */
-                test_div.innerHTML = '<img src="http://' + ip + ':' + port + 
+                test_div.innerHTML = '<img src="http://' + host + 
                     '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
-                res_div.innerHTML += "http://" + ip + ":" + port + "<br />";
+                res_div.innerHTML += "http://" + host + "<br />";
 
                 // XXX: What's the right way to do this in JS?
                 var thiss = this;
@@ -106,10 +105,10 @@
 
                 /* Create the div to load the image, passing our object's index into
                     the global directory so that it can be retrieved. */
-                test_div.innerHTML = '<img src="https://' + ip + ':' + port + 
+                test_div.innerHTML = '<img src="https://' + host + 
                     '" alt="" onerror="error_handler(' + our_scanobj_index + ');" />';
 
-                res_div.innerHTML += "https://" + ip + ":" + port + "<br />";
+                res_div.innerHTML += "https://" + host + "<br />";
 
                 // XXX: What's the right way to do this in JS?
                 var thiss = this;
@@ -126,8 +125,8 @@
 
             this.ws = function() {
             return new Promise((resolve, reject) => {
-                var ws = new WebSocket("ws://" + ip +":" + port + '/')
-                res_div.innerHTML += "ws://" + ip + ":" + port + "<br />";
+                var ws = new WebSocket("ws://" + host + '/')
+                res_div.innerHTML += "ws://" + host + "<br />";
                 ws.onerror = function() {
                 // close the socket before we return
                 ws.close()
@@ -137,8 +136,8 @@
 
             this.wss = function() {
             return new Promise((resolve, reject) => {
-                var ws = new WebSocket("wss://" + ip +":" + port + '/')
-                res_div.innerHTML += "wss://" + ip + ":" + port + "<br />";
+                var ws = new WebSocket("wss://" + host + '/')
+                res_div.innerHTML += "wss://" + host + "<br />";
                 ws.onerror = function() {
                 // close the socket before we return
                 ws.close()

--- a/TestPortScans.html
+++ b/TestPortScans.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>All in One Port-Scan Test</title>
     <style>
-        #main_content {
+        main {
             border: solid black 5px;
             border-radius: 10px;
             background-color: #da5a5a;
@@ -17,6 +17,7 @@
             text-align: center;
             padding-top: 10px;
             color: white;
+            font-weight: bold;
         }
 
         #custom_button {
@@ -27,42 +28,26 @@
     </style>
 </head>
 <body>
-    <div id="main_content">
+    <main>
+        <h1>All in One Port-Scan Test</h1>
 
-        <p>
-            <strong style="font-size: 30px;">All in One Port-Scan Test</strong>
-        </p>
-
-        <input type="button"id="custom_button" value="Port Scan My Internal Network!" onclick="custom_scan();" />
+        <button id="custom_button" onclick="custom_scan();">Port Scan My Internal Network!</button>
         
-        <div>
-            <br>
-            <p>
-                <strong>
-                    By clicking the button above, you understand that this is a portscanning test that happens inside your browser and is specifically built to test all the possible ways a site can port scan you in one easy location. 
-                    It will also try to reach out to specific domains that are known for distributing privacy-invasive scripts but will not attempt to download these scripts. NO DATA WILL EVER BE LOGGED OR SENT TO ME!
-                    <br>   
-                    <div>
-                        <a href="https://addons.mozilla.org/en-US/firefox/addon/port-authority/">
-                            <img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt="for Firefox" height="60px" />
-                        </a>
-                    </div> 
-                    <br>
-                    If you download the Port Authority add-on, your browser will block all malicious port scans and scripts.
-                </strong>        
-            </p>
-        </div>
-            <p style="font-weight: bold;visibility: hidden;font-size: 26px;" id="requestsmade">
-                <strong>
-                    Requests Made
-                </strong>
-            </p>
-        <div>
-            <div id="results" style="padding-top: 10px; font-weight: bold;"></div>
-        </div>
-
-    </div>
-
+        <p>
+            By clicking the button above, you understand that this is a portscanning test that happens inside your browser and is specifically built to test all the possible ways a site can port scan you in one easy location. 
+            It will also try to reach out to specific domains that are known for distributing privacy-invasive scripts but will not attempt to download these scripts. NO DATA WILL EVER BE LOGGED OR SENT TO ME!
+        </p>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/port-authority/">
+            <img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt="for Firefox" height="60px" />
+        </a>
+        <p>
+            If you download the Port Authority add-on, your browser will block all malicious port scans and scripts.
+        </p>
+        <h2 id="requestsmade" style="visibility: hidden;">
+            Requests Made
+        </h2>
+        <div id="results" style="padding-top: 10px; font-weight: bold;"></div>
+    </main>
 
     <div id="testdiv" style="visibility: hidden"></div>
 


### PR DESCRIPTION
Fixes a bug where the test page was only running the portscan on one port if multiple were specified. That fix was needed to test Popup styling for when many ports on the same domain had been scanned.

Also simplifies the HTML and CSS of the page without making any (visible) changes.

If it's ok with @ACK-J, I can redesign the page to use brand colors and a prettier layout. Just didn't want to step on toes by doing a full redesign right off the bat :).

Can be merged as-is, or kept around to accumulate design tweaks and improvements (that's why it's a draft).