### PR TITLE
Remove unneeded same-origin double checking, fixes #59

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,20 +23,8 @@ const thm = new RegExp("online-metrix[.]net$", "i");
 async function cancel(requestDetails) {
     // First check if it's a same-origin request
     if(!requestDetails.thirdParty) {
-        try {
-            const origin = new URL(requestDetails.originUrl);
-            const request = new URL(requestDetails.url);
-
-            // Also want to run our own check, for paranoia's sake
-            if(origin.origin === request.origin) {
-                console.log("Same-origin/first-party request allowed:", {origin, request, thirdParty: requestDetails.thirdParty});
-                return { cancel: false };
-            } else {
-                console.warn("`requestDetails.thirdParty` and our check of origins disagree:", {origin, request, thirdParty: requestDetails.thirdParty});
-            }
-        } catch(error) {
-            console.error("Error parsing request `originUrl` or `url`:", requestDetails, error);
-        }
+        console.debug("Same-origin/first-party request allowed:", {origin: requestDetails.originUrl, request: requestDetails.url});
+        return { cancel: false };
     }
 
 


### PR DESCRIPTION
The double-checking erroneously fails different-protocol (eg. `ws://`) requests and also errors when `requestDetails.originUrl` is `undefined`, which occurs when pasting a URL into the bar instead of clicking a link.
It's safe to remove since it's entirely redundant, the browser's `requestDetails.thirdParty` value is enough. I think I initially added it to see what cases caused `requestDetails.thirdParty` to be true yet `originUrl.origin` and `request.origin` to differ, turns out there are some valid times when that occurs, whoops :/